### PR TITLE
ci: test modern python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,17 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-3.7", "pypy-3.8", "pypy-3.9"]
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "pypy-3.7"
+          - "pypy-3.8"
+          - "pypy-3.9"
+          - "pypy-3.10"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,11 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
-          - "pypy-3.7"
           - "pypy-3.8"
           - "pypy-3.9"
           - "pypy-3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 build==0.7.0
 pre-commit==2.16.0
-#TODO Add pyodbc when it supports 3.11 - https://github.com/mkleehammer/pyodbc/issues/917
-pyodbc==4.0.32; platform_python_implementation != "PyPy" and python_version < '3.11'
+pyodbc==4.0.32; platform_python_implementation != "PyPy"
 pytest==6.2.5
 tox==3.24.5
 twine==3.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 build==0.7.0
 pre-commit==2.16.0
-pyodbc==4.0.32; platform_python_implementation != "PyPy"
-pytest==6.2.5
+pyodbc==5.1.0; platform_python_implementation != "PyPy"
+pytest==8.3.2
 tox==3.24.5
 twine==3.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,11 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Database
@@ -30,7 +30,7 @@ classifiers =
 
 [options]
 packages = purepyodbc
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = true
 
 [options.package_data]


### PR DESCRIPTION
Add CPython 3.12, and PyPy 3.10

Enables pyodbc compat tests for CPython >= 3.11

closes #2 