### PR TITLE
test: un-skip `test_emoticons_as_literal` on windows with postgresql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,4 +89,4 @@ jobs:
       run: poetry install
 
     - name: Run tests
-      run: poetry run pytest
+      run: poetry run pytest -v

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -1,4 +1,3 @@
-import platform
 import uuid
 
 from purepyodbc import Error, ProgrammingError
@@ -83,18 +82,6 @@ def test_emoticons_as_literal(cursor, connection_string):
     if "freetds" in connection_string.lower():
         # https://github.com/FreeTDS/freetds/issues/317
         check_freetds_version()
-
-    if "windows" in platform.platform().lower():
-        if "postgres" in connection_string.lower():
-            # https://stackoverflow.com/a/38487921/5567657
-            temp = cursor.connection.cursor()
-            temp.execute("SET client_encoding TO 'UTF8';")
-            temp.execute("SHOW server_encoding;")
-            server_enc = temp.fetchone().server_encoding
-            if server_enc.lower() != "utf8":
-                # https://stackoverflow.com/a/19391061/5567657
-                # https://github.com/ikalnytskyi/action-setup-postgres/issues/3
-                pytest.skip("PostgreSQL is not in UTF8 character set!")
 
     v = "x \U0001f31c z"
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -62,27 +62,6 @@ def test_illegal_fetchone_raises(cursor):
 
 
 def test_emoticons_as_literal(cursor, connection_string):
-    def check_freetds_version():
-        from subprocess import getstatusoutput
-
-        status, output = getstatusoutput("tsql -C")
-        if status != 0:
-            return
-        for line in output.split("\n"):
-            line = line.lower().strip()
-            version_line_start = "version: freetds v"
-            if line.startswith(version_line_start):
-                from packaging import version
-
-                freetds_version = version.parse(line.lstrip(version_line_start))
-                fixed_version = version.parse("1.1.23")
-                if freetds_version < fixed_version:
-                    pytest.xfail("Doesn't work in old versions of FreeTDS")
-
-    if "freetds" in connection_string.lower():
-        # https://github.com/FreeTDS/freetds/issues/317
-        check_freetds_version()
-
     v = "x \U0001f31c z"
 
     cursor.execute("drop table if exists t1")


### PR DESCRIPTION
This skip was added in 109e06d24498d081132272d1793d8c69bcd81f50 (around 2 years ago now) because it was failing on windows/postgresql in CI, but passing locally.

I raised [an action-setup-postgres issue](https://github.com/ikalnytskyi/action-setup-postgres/issues/3) which was kindly accommodated in [a subsequent pull request](https://github.com/ikalnytskyi/action-setup-postgres/pull/4).

Now that I have finally gotten around to adopting a newer version of that action in #13, it is time to see if this test passes...