### PR TITLE
fix: heap corruption in SQLGetData call

### DIFF
--- a/purepyodbc/_driver_manager.py
+++ b/purepyodbc/_driver_manager.py
@@ -385,7 +385,7 @@ class DriverManager:
             cursor.handle,
             column_description.column_number,
             -8,  # TODO: Don't hardcode SQL_C_WCHAR for SQLGetData..? Enum?
-            byref(buffer),
+            buffer,
             buffer_size,
             byref(length_or_indicator),
         )


### PR DESCRIPTION
Seeing sporadic errors in CI for MySQL on Windows. 

```
Windows fatal exception: code 0xc0000374
```

Hoping this fixes the issue...

[SQLGetData](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdata-function?view=sql-server-ver17#syntax) expects a pointer to a memory buffer, not a pointer to a pointer.