### PR TITLE
fix: Verify `cursor.foreignKeys` with MySQL

### DIFF
--- a/purepyodbc/_connection.py
+++ b/purepyodbc/_connection.py
@@ -66,6 +66,22 @@ class Connection(Handler):
             info_type=InfoType.SQL_IDENTIFIER_QUOTE_CHAR,
         )
 
+    @property
+    def schema_term(self) -> str:
+        """A character string with the data source vendor's name for a schema; for example, "owner", "Authorization ID",
+        or "Schema".
+
+        The character string can be returned in upper, lower, or mixed case.
+
+        A SQL-92 Entry level-conformant driver will always return "schema".
+
+        :return: A string with the data source vendor's name for a schema.
+        """
+        return self._driver_manager.sql_get_info(
+            connection=self,
+            info_type=InfoType.SQL_SCHEMA_TERM,
+        )
+
     def cursor(self) -> Cursor:
         cur = Cursor(self._driver_manager, self)
         return cur

--- a/purepyodbc/_cursor.py
+++ b/purepyodbc/_cursor.py
@@ -82,6 +82,11 @@ class Cursor(Handler):
         return rows
 
     def fetchone(self) -> Row | None:
+        """Fetch the next row of a query result set, returning a single sequence, or None when no more data is
+        available.
+
+        :return: A single row, or None when no more data is available.
+        """
         if not self._driver_manager.sql_fetch(self):
             return None
         row = Row()

--- a/purepyodbc/_enums.py
+++ b/purepyodbc/_enums.py
@@ -110,6 +110,7 @@ class InfoType(Enum):
     SQL_SEARCH_PATTERN_ESCAPE = 14
     SQL_DBMS_NAME = 17
     SQL_IDENTIFIER_QUOTE_CHAR = 29
+    SQL_SCHEMA_TERM = 39
 
 
 class SqlColumnAttrType(Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ wrap-descriptions = 120
 [tool.mypy]
 strict = true
 
+[tool.pytest.ini_options]
+xfail_strict = true
+
 [tool.ruff]
 fix = true
 unsafe-fixes = true

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -25,3 +25,15 @@ def test_autocommit(connection: Connection) -> None:
     assert connection.autocommit is True
     connection.autocommit = False
     assert connection.autocommit is False
+
+
+def test_schema_term(connection: Connection) -> None:
+    expected = {
+        "Microsoft SQL Server": "owner",
+        "PostgreSQL": "schema",
+        "MySQL": "",
+    }[connection.dbms_name]
+
+    schema_term = connection.schema_term
+
+    assert schema_term == expected


### PR DESCRIPTION
Verify that the `cursor.foreignKeys` method works correctly with MySQL.

I finally worked out this compatibility test was failing because, to my surprise, pyodbc doesn't return any result set against MySQL.

Once I came to terms with that, I took this test beyond mere compatibility with pyodbc and asserted more about the result set from purepyodbc.

Another source of temporary confusion was that the `pktable_schem` and `fktable_schem` values were `None` for MySQL. If you look at the `mysql-connector-odbc` [source](https://github.com/mysql/mysql-connector-odbc/blob/9111134d6c7d821e08b9b9958b27fe9729c4fa13/driver/catalog.cc#L1663C1-L1666C75), the value is null if the schema name was not passed to SQLForeignKeys:

```
  if(!pk_schema_len)
    query.append("A.TABLE_SCHEMA AS FKTABLE_CAT, NULL AS FKTABLE_SCHEM,");
  else
    query.append("NULL AS FKTABLE_CAT, A.TABLE_SCHEMA AS FKTABLE_SCHEM,");
```

[See also](https://dev.mysql.com/doc/connector-odbc/en/connector-odbc-usagenotes-functionality-catalog-schema.html):

> Many relational databases reference CATALOG and SCHEMA in ways that do not directly correspond to what MySQL refers to as a database. It is neither a CATALOG nor a SCHEMA. Generally, catalogs are collections of schemas, so the fully qualified name would look like catalog.schema.table.column. Historically with MySQL ODBC Driver, CATALOG and DATABASE were two names used for the same thing. At the same time SCHEMA was often used as a synonym for a MySQL Database. This would suggest that CATALOG equals a SCHEMA, which is incorrect, but in the MySQL Server context they would be the same thing. 


