### PR TITLE
fix: guard against double SQLDisconnect

### DIFF
--- a/purepyodbc/_connection.py
+++ b/purepyodbc/_connection.py
@@ -102,6 +102,8 @@ class Connection(Handler):
         self._driver_manager.sql_end_tran(self, CompletionType.SQL_ROLLBACK)
 
     def close(self) -> None:
+        if self._closed:
+            return
         if not self.autocommit:
             self.rollback()
         self._driver_manager.sql_disconnect(self)

--- a/purepyodbc/_driver_manager.py
+++ b/purepyodbc/_driver_manager.py
@@ -280,6 +280,8 @@ class DriverManager:
         self.check_success(ret, handler)
 
     def sql_free_handle(self, handler: Handler) -> None:
+        if not handler.handle or not handler.handle.value:
+            return
         return_code = self.cdll.SQLFreeHandle(handler.handle_type.value, handler.handle)
         self.check_success(return_code, handler)
 
@@ -305,6 +307,8 @@ class DriverManager:
         self.check_success(return_code, connection)
 
     def sql_disconnect(self, connection: Connection) -> None:
+        if not connection.handle or not connection.handle.value:
+            return
         self.check_success(self.cdll.SQLDisconnect(connection.handle), connection)
 
     def sql_exec_direct(self, cursor: Cursor, query_string: str) -> None:


### PR DESCRIPTION
Spotted on a recent pytest run on master:

```
tests/test_cursor.py::test_fetchmany_arraysize[MySQL ANSI-2] PASSED      [ 21%]
tests/test_cursor.py::test_fetchmany_arraysize[MySQL ANSI-3] PASSED      [ 21%]
Windows fatal exception: code 0xc0000374

Current thread 0x000019f0 (most recent call first):
  File "D:\a\purepyodbc\purepyodbc\purepyodbc\_driver_manager.py", line 308 in sql_disconnect
  File "D:\a\purepyodbc\purepyodbc\purepyodbc\_connection.py", line 107 in close
  File "D:\a\purepyodbc\purepyodbc\purepyodbc\_handler.py", line 33 in __exit__
  File "D:\a\purepyodbc\purepyodbc\tests\conftest.py", line 124 in connection
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\fixtures.py", line 907 in _teardown_yield_fixture
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\fixtures.py", line 1021 in finish
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\runner.py", line 546 in teardown_exact
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\runner.py", line 189 in pytest_runtest_teardown
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\runner.py", line 242 in <lambda>
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\runner.py", line 341 in from_call
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\runner.py", line 241 in call_and_report
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\runner.py", line 137 in runtestprotocol
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\runner.py", line 113 in pytest_runtest_protocol
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\main.py", line 362 in pytest_runtestloop
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\main.py", line 337 in _main
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\main.py", line 283 in wrap_session
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\main.py", line 330 in pytest_cmdline_main
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\config\__init__.py", line 175 in main
  File "D:\a\purepyodbc\purepyodbc\.venv\lib\site-packages\_pytest\config\__init__.py", line 201 in console_main
  File "D:\a\purepyodbc\purepyodbc\.venv\Scripts\pytest.exe\__main__.py", line 10 in <module>
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\runpy.py", line 87 in _run_code
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\runpy.py", line 197 in _run_module_as_main
tests/test_cursor.py::test_fetchmany_arraysize[MySQL ANSI-4] PASSED      [ 22%]
Error: Process completed with exit code 127.
```

Suspect that somehow sql_disconnect is being called twice sporadically, because this failed for one runner (cpython 3.9, windows) and not for others. But not sure.

At the very least, adding defensive guards will do no harm.